### PR TITLE
28-feature-패키지-번들링-최적화

### DIFF
--- a/.changeset/twenty-monkeys-cry.md
+++ b/.changeset/twenty-monkeys-cry.md
@@ -1,0 +1,11 @@
+---
+"@hensley-ui/react-button": patch
+---
+
+feat: optimize bundle size and improve documentation
+
+- Add external dependencies (clsx, tailwind-merge) to reduce bundle size by ~90%
+- Add bundle analysis tools with rollup-plugin-visualizer
+- Update README.md with comprehensive English documentation
+- Add peer dependencies for better dependency management
+- Include bundle size analysis script for monitoring

--- a/.changeset/twenty-monkeys-cry.md
+++ b/.changeset/twenty-monkeys-cry.md
@@ -8,4 +8,4 @@ feat: optimize bundle size and improve documentation
 - Add bundle analysis tools with rollup-plugin-visualizer
 - Update README.md with comprehensive English documentation
 - Add peer dependencies for better dependency management
-- Include bundle size analysis script for monitoring
+- Include bundle size analysis script for **monitoring**

--- a/packages/ui/react-button/README.md
+++ b/packages/ui/react-button/README.md
@@ -8,7 +8,23 @@ A flexible and accessible button component built with React and Radix UI.
 npm install @hensley-ui/react-button
 ```
 
-**Note:** This package depends on `@hensley-ui/utils`. It will be installed automatically.
+## Peer Dependencies
+
+This library requires the following peer dependencies:
+
+```bash
+npm install clsx tailwind-merge
+```
+
+Or if you're using yarn:
+
+```bash
+yarn add clsx tailwind-merge
+```
+
+```bash
+pnpm add clsx tailwind-merge
+```
 
 ## Usage
 
@@ -17,35 +33,66 @@ import { Button } from '@hensley-ui/react-button'
 
 function App() {
   return (
-    <div>
-      <Button>Click me</Button>
-      <Button variant="destructive">Delete</Button>
-      <Button size="lg">Large Button</Button>
-    </div>
+    <Button variant="default" size="lg">
+      Click me
+    </Button>
   )
 }
 ```
 
-## Props
+## API
 
-The Button component accepts all standard button props plus:
+### Button Props
 
-- `variant`: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'
-- `size`: 'default' | 'sm' | 'lg' | 'icon'
-- `asChild`: boolean - renders as child component using Radix UI Slot
+| Prop      | Type                                                                        | Default   | Description             |
+| --------- | --------------------------------------------------------------------------- | --------- | ----------------------- |
+| variant   | 'default' \| 'destructive' \| 'outline' \| 'secondary' \| 'ghost' \| 'link' | 'default' | Button style variant    |
+| size      | 'default' \| 'sm' \| 'lg' \| 'icon'                                         | 'default' | Button size             |
+| fullWidth | boolean                                                                     | false     | Use full width          |
+| asChild   | boolean                                                                     | false     | Render as child element |
+
+## Examples
+
+### Basic Usage
+
+```tsx
+<Button>Default Button</Button>
+<Button variant="destructive">Delete</Button>
+<Button variant="outline">Outline</Button>
+```
+
+### Sizes
+
+```tsx
+<Button size="sm">Small</Button>
+<Button size="default">Default</Button>
+<Button size="lg">Large</Button>
+<Button size="icon">🔍</Button>
+```
+
+### States
+
+```tsx
+<Button disabled>Disabled</Button>
+<Button fullWidth>Full Width</Button>
+<Button asChild>
+  <a href="#">As Link</a>
+</Button>
+```
 
 ## Dependencies
 
 This package includes:
 
-- `@hensley-ui/utils` - For class name utilities (cn function)
 - `@radix-ui/react-slot` - For asChild functionality
 - `class-variance-authority` - For variant management
 
 ## Peer Dependencies
 
-- `react` >= 18.2.0
-- `react-dom` >= 18.2.0
+- `react` >= 18.0.0-rc < 20.0.0
+- `@types/react` >= 18.0.0-rc < 20.0.0
+- `clsx` ^2.1.1
+- `tailwind-merge` ^2.6.0
 
 ## License
 

--- a/packages/ui/react-button/analyze.js
+++ b/packages/ui/react-button/analyze.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const distPath = path.join(__dirname, 'dist')
+const statsPath = path.join(distPath, 'stats.html')
+const bundlePath = path.join(distPath, 'index.mjs')
+
+console.log('📊 React Button 빌드 분석 결과:')
+console.log('')
+
+if (fs.existsSync(statsPath)) {
+  console.log('✅ 분석 파일이 생성되었습니다:')
+  console.log(`📁 파일 위치: ${statsPath}`)
+  console.log(`🌐 브라우저에서 열기: file://${statsPath}`)
+} else {
+  console.log('❌ 분석 파일이 생성되지 않았습니다.')
+}
+
+if (fs.existsSync(bundlePath)) {
+  const stats = fs.statSync(bundlePath)
+  const sizeInKB = (stats.size / 1024).toFixed(2)
+  console.log(`📈 번들 크기: ${sizeInKB} KB`)
+
+  // Gzip 크기 계산
+  const { execSync } = await import('child_process')
+  try {
+    const gzipSize = execSync(`gzip -c "${bundlePath}" | wc -c`, {
+      encoding: 'utf8',
+    })
+    const gzipSizeInKB = (parseInt(gzipSize.trim()) / 1024).toFixed(2)
+    console.log(`🗜️  Gzip 크기: ${gzipSizeInKB} KB`)
+  } catch {
+    console.log('⚠️  Gzip 크기 계산 실패')
+  }
+} else {
+  console.log('❌ 번들 파일을 찾을 수 없습니다.')
+}
+
+console.log('')
+console.log(
+  '💡 팁: stats.html 파일을 브라우저에서 열어서 상세한 번들 분석을 확인하세요!',
+)

--- a/packages/ui/react-button/package.json
+++ b/packages/ui/react-button/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "build:analyze": "vite build && node analyze.js",
+    "build:analyze": "ANALYZE=true vite build && node analyze.js",
     "dev": "vite build --watch",
     "clean": "rimraf .turbo node_modules dist",
     "test": "vitest run --passWithNoTests",

--- a/packages/ui/react-button/package.json
+++ b/packages/ui/react-button/package.json
@@ -38,18 +38,19 @@
     "@hensley-ui/typescript-config": "workspace:*",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "clsx": "^2.1.1",
     "jsdom": "^26.1.0",
+    "rollup-plugin-visualizer": "^6.0.3",
+    "tailwind-merge": "^2.6.0",
     "typescript": "^5.0.0",
     "vite": "^5.0.0",
     "vite-plugin-dts": "^3.7.0",
-    "vitest": "^3.1.1",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^2.6.0"
+    "vitest": "^3.1.1"
   },
   "peerDependencies": {
-    "react": ">=18.0.0-rc <20.0.0",
     "@types/react": ">=18.0.0-rc <20.0.0",
     "clsx": "^2.1.1",
+    "react": ">=18.0.0-rc <20.0.0",
     "tailwind-merge": "^2.6.0"
   }
 }

--- a/packages/ui/react-button/package.json
+++ b/packages/ui/react-button/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "build": "vite build",
+    "build:analyze": "vite build && node analyze.js",
     "dev": "vite build --watch",
     "clean": "rimraf .turbo node_modules dist",
     "test": "vitest run --passWithNoTests",
@@ -41,10 +42,14 @@
     "typescript": "^5.0.0",
     "vite": "^5.0.0",
     "vite-plugin-dts": "^3.7.0",
-    "vitest": "^3.1.1"
+    "vitest": "^3.1.1",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.6.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0-rc <20.0.0",
-    "@types/react": ">=18.0.0-rc <20.0.0"
+    "@types/react": ">=18.0.0-rc <20.0.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.6.0"
   }
 }

--- a/packages/ui/react-button/src/utils.ts
+++ b/packages/ui/react-button/src/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/packages/ui/react-button/vite.config.ts
+++ b/packages/ui/react-button/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import { resolve } from 'path'
 import dts from 'vite-plugin-dts'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 export default defineConfig({
   build: {
@@ -12,7 +13,13 @@ export default defineConfig({
       fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`,
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'clsx',
+        'tailwind-merge',
+      ],
       output: {
         exports: 'named',
         globals: {
@@ -39,6 +46,13 @@ export default defineConfig({
         '**/*.spec.*',
         '**/vitest.config.*',
       ],
+    }),
+    visualizer({
+      filename: 'dist/stats.html',
+      open: true,
+      gzipSize: true,
+      brotliSize: true,
+      template: 'treemap',
     }),
   ],
 })

--- a/packages/ui/react-button/vite.config.ts
+++ b/packages/ui/react-button/vite.config.ts
@@ -47,12 +47,16 @@ export default defineConfig({
         '**/vitest.config.*',
       ],
     }),
-    visualizer({
-      filename: 'dist/stats.html',
-      open: true,
-      gzipSize: true,
-      brotliSize: true,
-      template: 'treemap',
-    }),
+    ...(process.env.ANALYZE === 'true'
+      ? [
+          visualizer({
+            filename: 'dist/stats.html',
+            open: true,
+            gzipSize: true,
+            brotliSize: true,
+            template: 'treemap',
+          }),
+        ]
+      : []),
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      rollup-plugin-visualizer:
+        specifier: ^6.0.3
+        version: 6.0.3
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -7657,6 +7660,25 @@ packages:
       - ts-node
     dev: true
 
+  /rollup-plugin-visualizer@6.0.3:
+    resolution: {integrity: sha512-ZU41GwrkDcCpVoffviuM9Clwjy5fcUxlz0oMoTXTYsK+tcIFzbdacnrr2n8TXcHxbGKKXtOdjxM2HUS4HjkwIw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      rolldown: 1.x || ^1.0.0-beta
+      rollup: 2.x || 3.x || 4.x
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+    dependencies:
+      open: 8.4.2
+      picomatch: 4.0.2
+      source-map: 0.7.6
+      yargs: 17.7.2
+    dev: true
+
   /rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
     dependencies:
@@ -7877,6 +7899,11 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
     dev: true
 
   /spawndamnit@3.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,9 +207,15 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@19.1.0)(react@19.1.0)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      tailwind-merge:
+        specifier: ^2.6.0
+        version: 2.6.0
       typescript:
         specifier: ^5.0.0
         version: 5.6.3
@@ -4463,7 +4469,6 @@ packages:
   /clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-    dev: false
 
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -8108,7 +8113,6 @@ packages:
 
   /tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
-    dev: false
 
   /tailwindcss-animate@1.0.7(tailwindcss@3.3.5):
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}


### PR DESCRIPTION
| 항목        | 내용 |
|-------------|------|
| 🔗 관련 이슈 |  [#28 패키지 번들링 최적화](https://github.com/sooster910/hensley-ui/issues/28) |
| 🏷️ 작업 타입 | Chore / Build Optimization |
| 📦 변경 범위 | react-button 패키지 |


## 배경 (Problem) 

-  react-button, react-heading 등 현재 배포된 패키지들이 tailwind-merge, clsx를 번들에 포함하고 있어 라이브러리 번들 크기가 불필요하게 커집니다. 패키지 크기: unpacked 92.4KB - 단일 컴포넌트 라이브러리치고 과도하게 큰 크기
- 사용자 프로젝트가 이미 같은 의존성을 사용 중이면 최종(앱) 번들에 중복으로 포함되어 전체 번들 크기가 증가합니다.
- clsx는 클래스 결합만 처리하지만 Tailwind의 우선순위/충돌 해결(예: twMerge)을 하지 못하므로 tailwind-merge 사용이 필요합니다.


## 원인분석 

번들 크기 92.4KB 구성 분석에서 2000 줄이 넘는 tailwind-merge 가 전체 크기의 89% 차지 

<img width="1220" height="976" alt="tailwind" src="https://github.com/user-attachments/assets/9fc584c4-cd6d-432e-bc01-b714fae92a43" />


##  주요 변경사항

###  번들 크기 최적화  코드라인 : 2015→ 총 147 lines  (-93%), unpacked  92.4kb → 13.5kb(-85%)
- **외부 의존성 분리**: `clsx`, `tailwind-merge`를 peer dependencies로 이동
- **rollupOptions** 설정 

**왜 external 처리가 필요한가?**
peerDependencies로만 지정하면 패키지 설치 시 소비자가 해당 모듈을 설치해야 한다는 사실만 보장합니다.
하지만, 빌드 단계에서 별도로 external로 지정하지 않으면 번들러는 여전히 해당 모듈을 라이브러리 번들 안에 포함시켜 버릴 수 있습니다.

이를 방치하면 다음 문제가 발생합니다:
1. 번들 크기 증가
- clsx, tailwind-merge 같은 유틸리티가 라이브러리 번들에 포함되어 불필요하게 커짐.
	
2. 중복 의존성 문제
- 소비자 앱에서 이미 같은 라이브러리를 설치했을 경우, 최종 앱 번들에 중복 포함 → 불필요한 자원 낭비.

3. 버전 충돌 / 다중 인스턴스 문제

우리 라이브러리가 특정 버전의 clsx를 내장하고 있으면, 사용자 프로젝트가 다른 버전 clsx를 쓰고 있을 때 React Tree 안에서 서로 다른 clsx 인스턴스가 존재하게 되고 함수 레벨 유틸이라도 유지보수성 문제를 일으킬 수 있습니다. external로 처리하면 항상 사용자 프로젝트에서 설치한 단일 인스턴스만 존재하게 되어 안전합니다. 같은 맥락으로 clsx나 tailwind-merge도 프로젝트마다 다른 버전이 충돌할 수 있습니다.


- **번들 분석 도구 추가**: `rollup-plugin-visualizer`를 통한 번들 크기 모니터링
- **번들 분석 스크립트**: `analyze.js` 추가로 번들 크기 추적 가능

<img width="2795" height="1321" alt="번들사이즈감소" src="https://github.com/user-attachments/assets/bc7584b6-d230-450b-83cb-c3ed9bbabf7f" />


## 리스크 & 대응
1. 사용자가 peer deps를 설치하지 않음
- 영향: 런타임에서 모듈 미존재로 에러 발생 가능
- 대응: README에 명확한 설치 가이드 추가, 패키지 사용 시 친절한 에러 메시지(빌드 시 경고 스크립트 또는 런타임에서 설치 유무 체크 후 경고) 도입 고려

2.	버전 호환성 이슈
- 대응: peerDependencies에 버전 범위를 명시, 마이그레이션 가이드 제공
